### PR TITLE
Added the flag if: always() to the get commit hash step.

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -8,7 +8,9 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
+    - name: Get commit hash
+      if: ${{ always() }}
+      run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
       id: slug
     - name: Chat Setup
       if: ${{ always() }}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
+    - name: Get commit hash
+      if: ${{ always() }}
+      run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
       id: slug
     - name: Chat Setup
       if: ${{ always() }}


### PR DESCRIPTION
### What was done
- Added the flag `always()` to the step for get commit hash

### Motivation
I noticed when a previous step failed, the step to get the commit hash didn't execute so the step `chat setup` fails because it has not the `commit` input.

Failing example:
 ```yaml
    steps:
    - name: Checkout
      uses: actions/checkout@v2
    # Suppose the lint fails here
    - name: Lint
       run: npm run lint
    - run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
    - name: Get commit hash
      run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
      id: slug
    - name: Chat Setup
      if: ${{ always() }}
```

The following error will occur:
![imagen](https://user-images.githubusercontent.com/45211582/107659415-e4bcb080-6c65-11eb-9e02-95b1c63f9838.png)


Working example:
 ```yaml
    steps:
    - name: Checkout
      uses: actions/checkout@v2
    # Suppose the lint fails here
    - name: Lint
       run: npm run lint
    - run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
    - name: Get commit hash
      if: ${{ always() }}
      run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
      id: slug
    - name: Chat Setup
      if: ${{ always() }}
```

![imagen](https://user-images.githubusercontent.com/45211582/107662122-b68ca000-6c68-11eb-9bc8-77b666fe2733.png)

And the alert is generated ok:
<img width="392" alt="imagen" src="https://user-images.githubusercontent.com/45211582/107662209-cdcb8d80-6c68-11eb-8419-5dd37b823d4d.png">


Please let me know if you have any concern.

Cheers.